### PR TITLE
[CI/CD] Fix pipeline badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Executive Tasks - Elegant Todo List
 
-![Tests](https://github.com/StargrrlMoonlight/SettingUpMcpServers/actions/workflows/ci.yml/badge.svg)
+![CI/CD Status](https://github.com/StargrrlMoonlight/SettingUpMcpServers/actions/workflows/ci.yml/badge.svg?branch=main)
 ![Coverage](https://img.shields.io/badge/coverage-82%25-success)
 [![code style: eslint](https://img.shields.io/badge/code%20style-eslint-blue.svg)](https://eslint.org/)
 


### PR DESCRIPTION
This PR fixes the CI/CD pipeline badge in the README to correctly show the current status and use a more accurate label.

## Changes
- Updated badge label from "Tests" to "CI/CD Status" for clarity
- Added `?branch=main` parameter to the badge URL to ensure it shows status for the main branch

## Related Issues
Closes #12