### PR TITLE
🔄 Reverse CI coverage badge update strategy to work with branch protection

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -105,7 +105,7 @@ jobs:
         echo "Coverage: $COVERAGE%"
       
     - name: Update README with coverage badge
-      if: matrix.node-version == '20.x' && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: matrix.node-version == '20.x' && github.ref != 'refs/heads/main' && github.event_name == 'push'
       run: |
         # Install bc for floating point comparison
         sudo apt-get update && sudo apt-get install -y bc
@@ -134,7 +134,7 @@ jobs:
         sed -i -E "s|!\[Coverage\]\(https://img.shields.io/badge/coverage-[0-9]+(\.[0-9]+)?%25-[a-zA-Z]+\)|![Coverage]($BADGE_URL)|g" README.md
         
     - name: Commit updated README with coverage badge
-      if: matrix.node-version == '20.x' && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: matrix.node-version == '20.x' && github.ref != 'refs/heads/main' && github.event_name == 'push'
       run: |
         # Configure git with a name and email
         git config --global user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary
Reverses the CI workflow logic to update the README coverage badge on feature branches instead of the main branch, solving the branch protection conflict.

## Changes Made
- **Updated workflow conditions**: Changed from `github.ref == 'refs/heads/main'` to `github.ref != 'refs/heads/main'`
- **Coverage badge updates**: Now occur on feature branch pushes instead of main branch pushes
- **Automatic inclusion**: When PRs are merged, the updated README with correct coverage badge is included

## Problem Solved
- ✅ **Branch Protection Compliance**: No longer attempts to push directly to protected main branch
- ✅ **Automated Documentation**: Coverage badge stays current with each feature branch
- ✅ **Simplified Workflow**: Removes need for complex branch protection bypass attempts
- ✅ **Better CI/CD Practices**: Follows standard feature branch workflow patterns

## Testing
The workflow will be tested automatically when this PR is created and pushes occur to this feature branch.

## Related Issue
Closes #45

## Screenshots/Demo
The workflow will update the README coverage badge on this feature branch, demonstrating the fix in action.

---
**Ready for Copilot Review** 🤖